### PR TITLE
Fix typos on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
           Focus Music App
           <small class="vsmall"><a href="https://github.com/vasanthv/focus-music">View in Github</a></small>
         </h2>
-        <p>This tiny app help your get more focus while you are working. The music in te app stimulates the focus part of your brian to create more focus. It also helps you timebox your work into 30min & 60min blocks.</p>
+        <p>This tiny app help your get more focus while you are working. The music in the app stimulates the focus part of your brain to create more focus. It also helps you timebox your work into 30min & 60min blocks.</p>
         <p>
-            Download available for <a href="https://www.dropbox.com/s/le6picqmshfswct/focus-music.mac.zip?dl=0">Mac OSX</a>.
+            Download available for <a href="https://www.dropbox.com/s/le6picqmshfswct/focus-music.mac.zip?dl=0">macOS</a>.
             <small>You can build for <a href="https://github.com/vasanthv/focus-music#for-linux">Linux</a> & <a href="https://github.com/vasanthv/focus-music#for-windows">Windows</a></small>
         </p>
         <small>Source of music: <a href="https://archive.org/details/Brain.fm" target="_blank">Brain.fm: Music to improve focus, meditation & sleep</a></small>


### PR DESCRIPTION
te -> the
brian -> brain
also, OS X is [now called](https://en.wikipedia.org/wiki/MacOS#macOS) just "macOS"